### PR TITLE
Decouple config and auth package

### DIFF
--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -23,6 +23,8 @@ import (
 	"path"
 	"time"
 
+	"github.com/streamnative/pulsar-admin-go/pkg/admin/auth"
+	"github.com/streamnative/pulsar-admin-go/pkg/admin/config"
 	"github.com/streamnative/pulsar-admin-go/pkg/rest"
 	"github.com/streamnative/pulsar-admin-go/pkg/utils"
 )
@@ -60,12 +62,12 @@ type Client interface {
 
 type pulsarClient struct {
 	Client     *rest.Client
-	APIVersion APIVersion
+	APIVersion config.APIVersion
 }
 
 // New returns a new client
-func New(config *Config) (Client, error) {
-	authProvider, err := GetAuthProvider(config)
+func New(config *config.Config) (Client, error) {
+	authProvider, err := auth.GetAuthProvider(config)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +76,7 @@ func New(config *Config) (Client, error) {
 
 // NewWithAuthProvider creates a client with auth provider.
 // Deprecated: Use NewPulsarClientWithAuthProvider instead.
-func NewWithAuthProvider(config *Config, authProvider AuthProvider) Client {
+func NewWithAuthProvider(config *config.Config, authProvider auth.Provider) Client {
 	client, err := NewPulsarClientWithAuthProvider(config, authProvider)
 	if err != nil {
 		panic(err)
@@ -83,8 +85,8 @@ func NewWithAuthProvider(config *Config, authProvider AuthProvider) Client {
 }
 
 // NewPulsarClientWithAuthProvider create a client with auth provider.
-func NewPulsarClientWithAuthProvider(config *Config,
-	authProvider AuthProvider) (Client, error) {
+func NewPulsarClientWithAuthProvider(config *config.Config,
+	authProvider auth.Provider) (Client, error) {
 	var transport http.RoundTripper
 
 	if authProvider != nil {
@@ -95,7 +97,7 @@ func NewPulsarClientWithAuthProvider(config *Config,
 	}
 
 	if transport == nil {
-		defaultTransport, err := NewDefaultTransport(config)
+		defaultTransport, err := auth.NewDefaultTransport(config)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/admin/admin_test.go
+++ b/pkg/admin/admin_test.go
@@ -23,26 +23,29 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/streamnative/pulsar-admin-go/pkg/admin/auth"
+	"github.com/streamnative/pulsar-admin-go/pkg/admin/config"
 )
 
 func TestPulsarClientEndpointEscapes(t *testing.T) {
-	client := pulsarClient{Client: nil, APIVersion: V2}
+	client := pulsarClient{Client: nil, APIVersion: config.V2}
 	actual := client.endpoint("/myendpoint", "abc%? /def", "ghi")
 	expected := "/admin/v2/myendpoint/abc%25%3F%20%2Fdef/ghi"
 	assert.Equal(t, expected, actual)
 }
 
 func TestNew(t *testing.T) {
-	config := &Config{}
+	config := &config.Config{}
 	admin, err := New(config)
 	require.NoError(t, err)
 	require.NotNil(t, admin)
 }
 
 func TestNewWithAuthProvider(t *testing.T) {
-	config := &Config{}
+	config := &config.Config{}
 
-	tokenAuth, err := NewAuthenticationToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."+
+	tokenAuth, err := auth.NewAuthenticationToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."+
 		"eyJzdWIiOiJhZG1pbiIsImlhdCI6MTUxNjIzOTAyMn0.sVt6cyu3HKd89LcQvZVMNbqT0DTl3FvG9oYbj8hBDqU", nil)
 	require.NoError(t, err)
 	require.NotNil(t, tokenAuth)
@@ -56,7 +59,7 @@ type customAuthProvider struct {
 	transport http.RoundTripper
 }
 
-var _ AuthProvider = &customAuthProvider{}
+var _ auth.Provider = &customAuthProvider{}
 
 func (c *customAuthProvider) RoundTrip(req *http.Request) (*http.Response, error) {
 	panic("implement me")
@@ -71,8 +74,8 @@ func (c *customAuthProvider) WithTransport(transport http.RoundTripper) {
 }
 
 func TestNewWithCustomAuthProviderWithTransport(t *testing.T) {
-	config := &Config{}
-	defaultTransport, err := NewDefaultTransport(config)
+	config := &config.Config{}
+	defaultTransport, err := auth.NewDefaultTransport(config)
 	require.NoError(t, err)
 
 	customAuthProvider := &customAuthProvider{
@@ -88,7 +91,7 @@ func TestNewWithCustomAuthProviderWithTransport(t *testing.T) {
 }
 
 func TestNewWithTlsAllowInsecure(t *testing.T) {
-	config := &Config{
+	config := &config.Config{
 		TLSAllowInsecureConnection: true,
 	}
 	admin, err := New(config)

--- a/pkg/admin/auth/oauth2.go
+++ b/pkg/admin/auth/oauth2.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package admin
+package auth
 
 import (
 	"encoding/json"
@@ -71,7 +71,7 @@ func NewAuthenticationOAuth2(issuer oauth2.Issuer, store store.Store) (*OAuth2Pr
 }
 
 // NewAuthenticationOAuth2WithDefaultFlow uses memory to save the grant
-func NewAuthenticationOAuth2WithDefaultFlow(issuer oauth2.Issuer, keyFile string) (AuthProvider, error) {
+func NewAuthenticationOAuth2WithDefaultFlow(issuer oauth2.Issuer, keyFile string) (Provider, error) {
 	st := store.NewMemoryStore()
 	flow, err := oauth2.NewDefaultClientCredentialsFlow(oauth2.ClientCredentialsFlowOptions{
 		KeyFile: keyFile,

--- a/pkg/admin/auth/oauth2_test.go
+++ b/pkg/admin/auth/oauth2_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package admin
+package auth
 
 import (
 	"fmt"

--- a/pkg/admin/auth/tls.go
+++ b/pkg/admin/auth/tls.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package admin
+package auth
 
 import (
 	"crypto/tls"

--- a/pkg/admin/auth/token.go
+++ b/pkg/admin/auth/token.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package admin
+package auth
 
 import (
 	"encoding/json"
@@ -34,7 +34,7 @@ const (
 	TokePluginShortName = "token"
 )
 
-type AuthToken struct {
+type Token struct {
 	Token string `json:"token"`
 }
 
@@ -43,7 +43,7 @@ type TokenAuthProvider struct {
 	token string
 }
 
-// NewAuthenticationToken return a interface of AuthProvider with a string token.
+// NewAuthenticationToken return a interface of Provider with a string token.
 func NewAuthenticationToken(token string, transport http.RoundTripper) (*TokenAuthProvider, error) {
 	if len(token) == 0 {
 		return nil, errors.New("No token provided")
@@ -51,7 +51,7 @@ func NewAuthenticationToken(token string, transport http.RoundTripper) (*TokenAu
 	return &TokenAuthProvider{token: token, T: transport}, nil
 }
 
-// NewAuthenticationTokenFromFile return a interface of a AuthProvider with a string token file path.
+// NewAuthenticationTokenFromFile return a interface of a Provider with a string token file path.
 func NewAuthenticationTokenFromFile(tokenFilePath string, transport http.RoundTripper) (*TokenAuthProvider, error) {
 	data, err := ioutil.ReadFile(tokenFilePath)
 	if err != nil {
@@ -66,7 +66,7 @@ func NewAuthenticationTokenFromAuthParams(encodedAuthParam string,
 	var tokenAuthProvider *TokenAuthProvider
 	var err error
 
-	var tokenJSON AuthToken
+	var tokenJSON Token
 	err = json.Unmarshal([]byte(encodedAuthParam), &tokenJSON)
 	if err != nil {
 		switch {

--- a/pkg/admin/auth/transport.go
+++ b/pkg/admin/auth/transport.go
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/streamnative/pulsar-admin-go/pkg/admin/config"
+)
+
+type Transport struct {
+	T http.RoundTripper
+}
+
+// GetDefaultTransport gets a default transport.
+// Deprecated: Use NewDefaultTransport instead.
+func GetDefaultTransport(config *config.Config) http.RoundTripper {
+	transport, err := NewDefaultTransport(config)
+	if err != nil {
+		panic(err)
+	}
+
+	return transport
+}
+
+func NewDefaultTransport(config *config.Config) (http.RoundTripper, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: config.TLSAllowInsecureConnection,
+	}
+	if len(config.TLSTrustCertsFilePath) > 0 {
+		rootCA, err := ioutil.ReadFile(config.TLSTrustCertsFilePath)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.RootCAs = x509.NewCertPool()
+		tlsConfig.RootCAs.AppendCertsFromPEM(rootCA)
+	}
+	transport.MaxIdleConnsPerHost = 10
+	transport.TLSClientConfig = tlsConfig
+	return transport, nil
+}

--- a/pkg/admin/config/api_version.go
+++ b/pkg/admin/config/api_version.go
@@ -15,18 +15,30 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package admin
+package config
 
-import (
-	"testing"
+type APIVersion int
 
-	"github.com/stretchr/testify/assert"
+const (
+	undefined APIVersion = iota
+	V1
+	V2
+	V3
 )
 
-func TestApiVersion_String(t *testing.T) {
-	assert.Equal(t, "", V1.String())
-	assert.Equal(t, "v2", V2.String())
-	assert.Equal(t, "v3", V3.String())
-	var undefinedAPIVersion APIVersion
-	assert.Equal(t, DefaultAPIVersion, undefinedAPIVersion.String())
+const DefaultAPIVersion = "v2"
+
+func (v APIVersion) String() string {
+	switch v {
+	case undefined:
+		return DefaultAPIVersion
+	case V1:
+		return ""
+	case V2:
+		return "v2"
+	case V3:
+		return "v3"
+	}
+
+	return DefaultAPIVersion
 }

--- a/pkg/admin/config/api_version_test.go
+++ b/pkg/admin/config/api_version_test.go
@@ -15,30 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package admin
+package config
 
-type APIVersion int
+import (
+	"testing"
 
-const (
-	undefined APIVersion = iota
-	V1
-	V2
-	V3
+	"github.com/stretchr/testify/assert"
 )
 
-const DefaultAPIVersion = "v2"
-
-func (v APIVersion) String() string {
-	switch v {
-	case undefined:
-		return DefaultAPIVersion
-	case V1:
-		return ""
-	case V2:
-		return "v2"
-	case V3:
-		return "v3"
-	}
-
-	return DefaultAPIVersion
+func TestApiVersion_String(t *testing.T) {
+	assert.Equal(t, "", V1.String())
+	assert.Equal(t, "v2", V2.String())
+	assert.Equal(t, "v3", V3.String())
+	var undefinedAPIVersion APIVersion
+	assert.Equal(t, DefaultAPIVersion, undefinedAPIVersion.String())
 }

--- a/pkg/admin/config/config.go
+++ b/pkg/admin/config/config.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package admin
+package config
 
 type Config struct {
 	// the web service url that pulsarctl connects to. Default is http://localhost:8080


### PR DESCRIPTION
Follow-up #3 

### Motivation
Respect the Single Responsibility Principle.

Actually all the auth providers are http.RoundTripper instance, they are just serving for admin resources operations.
Given that the Config is referenced by both admin and auth package, so decouple the pkg/config package to avoid cyclic import problems.

The root of pkg/admin package should focus on admin resources operations, so let's decouple non-resources operations codes.

A better package dependency graph should be:

```
admin.Client -> rest.Client -> auth.Provider
         \                     /
              config.Config 
```

### Modifications
- Add pkg/pulsar/config package
- Add pkg/pulsar/auth package