### PR TITLE
Add alias package

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsaradmin
+
+import (
+	"github.com/streamnative/pulsar-admin-go/pkg/admin"
+	"github.com/streamnative/pulsar-admin-go/pkg/admin/config"
+)
+
+// Client contains all admin interfaces for operating pulsar resources
+type Client = admin.Client
+
+// Config are the arguments for creating a new admin Client
+type Config = config.Config
+
+var (
+	// NewClient returns a new admin Client for operating pulsar resources
+	NewClient = admin.New
+)


### PR DESCRIPTION
### Motivation
While keeping the maintainability of overall project layout, an alias package can provide shortcuts for common types and functions to reduce import line bloat.

An example after this change:

```go
import (
	"github.com/streamnative/pulsar-admin-go"
)

func main() {
	cfg := &pulsaradmin.Config{}
	admin, err := pulsaradmin.NewClient(cfg)
}
```