### PR TITLE
fix: golangci-lint errors

### DIFF
--- a/pkg/admin/functions.go
+++ b/pkg/admin/functions.go
@@ -675,7 +675,9 @@ func (f *functions) Upload(sourceFile, path string) error {
 	if err != nil {
 		return err
 	}
-	w.WriteField("path", path)
+	if err := w.WriteField("path", path); err != nil {
+		return err
+	}
 	err = w.Close()
 	if err != nil {
 		return err

--- a/pkg/admin/subscription.go
+++ b/pkg/admin/subscription.go
@@ -27,7 +27,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" //nolint:staticcheck
 
 	"github.com/streamnative/pulsar-admin-go/pkg/utils"
 )

--- a/pkg/admin/token.go
+++ b/pkg/admin/token.go
@@ -106,7 +106,7 @@ func (t *token) CreateToken(
 	headers map[string]interface{}) (string, error) {
 	signMethod := parseAlgorithmToJwtSignMethod(algorithm)
 	tokenString := jwt.NewWithClaims(signMethod, mapClaims)
-	if headers != nil && len(headers) > 0 {
+	if len(headers) > 0 {
 		for s, i := range headers {
 			tokenString.Header[s] = i
 		}

--- a/pkg/algorithm/hmac/hs256.go
+++ b/pkg/algorithm/hmac/hs256.go
@@ -31,7 +31,9 @@ type HS256 struct{}
 
 func (h *HS256) GenerateSecret() ([]byte, error) {
 	bytes := make([]byte, 32)
-	rand.Read(bytes)
+	if _, err := rand.Read(bytes); err != nil {
+		return nil, err
+	}
 	s := hmac.New(sha256.New, bytes)
 	return s.Sum(nil), nil
 }

--- a/pkg/algorithm/hmac/hs384.go
+++ b/pkg/algorithm/hmac/hs384.go
@@ -31,7 +31,9 @@ type HS384 struct{}
 
 func (h *HS384) GenerateSecret() ([]byte, error) {
 	bytes := make([]byte, 48)
-	rand.Read(bytes)
+	if _, err := rand.Read(bytes); err != nil {
+		return nil, err
+	}
 	s := hmac.New(sha512.New384, bytes)
 	return s.Sum(nil), nil
 }

--- a/pkg/algorithm/hmac/hs512.go
+++ b/pkg/algorithm/hmac/hs512.go
@@ -31,7 +31,9 @@ type HS512 struct{}
 
 func (h *HS512) GenerateSecret() ([]byte, error) {
 	bytes := make([]byte, 64)
-	rand.Read(bytes)
+	if _, err := rand.Read(bytes); err != nil {
+		return nil, err
+	}
 	s := hmac.New(sha512.New, bytes)
 	return s.Sum(nil), nil
 }

--- a/pkg/rest/client.go
+++ b/pkg/rest/client.go
@@ -120,6 +120,7 @@ func (c *Client) GetWithOptions(endpoint string, obj interface{}, params map[str
 		req.params = query
 	}
 
+	//nolint:bodyclose
 	resp, err := checkSuccessful(c.doRequest(req))
 	if err != nil {
 		return nil, err
@@ -174,6 +175,7 @@ func (c *Client) PutWithQueryParams(endpoint string, in, obj interface{}, params
 		req.params = query
 	}
 
+	//nolint:bodyclose
 	resp, err := checkSuccessful(c.doRequest(req))
 	if err != nil {
 		return err
@@ -197,7 +199,7 @@ func (c *Client) PutWithMultiPart(endpoint string, body io.Reader, contentType s
 	req.body = body
 	req.contentType = contentType
 
-	// nolint
+	//nolint
 	resp, err := checkSuccessful(c.doRequest(req))
 	if err != nil {
 		return err
@@ -225,7 +227,7 @@ func (c *Client) DeleteWithQueryParams(endpoint string, params map[string]string
 		req.params = query
 	}
 
-	// nolint
+	//nolint
 	resp, err := checkSuccessful(c.doRequest(req))
 	if err != nil {
 		return err
@@ -246,7 +248,7 @@ func (c *Client) PostWithObj(endpoint string, in, obj interface{}) error {
 	}
 	req.obj = in
 
-	// nolint
+	//nolint
 	resp, err := checkSuccessful(c.doRequest(req))
 	if err != nil {
 		return err
@@ -270,7 +272,7 @@ func (c *Client) PostWithMultiPart(endpoint string, in interface{}, body io.Read
 	req.body = body
 	req.contentType = contentType
 
-	// nolint
+	//nolint
 	resp, err := checkSuccessful(c.doRequest(req))
 	if err != nil {
 		return err
@@ -295,7 +297,7 @@ func (c *Client) PostWithQueryParams(endpoint string, in interface{}, params map
 		}
 		req.params = query
 	}
-	// nolint
+	//nolint
 	resp, err := checkSuccessful(c.doRequest(req))
 	if err != nil {
 		return err

--- a/pkg/utils/message.go
+++ b/pkg/utils/message.go
@@ -17,7 +17,7 @@
 
 package utils
 
-// nolint
+//nolint
 import (
 	"github.com/golang/protobuf/proto"
 )

--- a/pkg/utils/namespace_name.go
+++ b/pkg/utils/namespace_name.go
@@ -81,7 +81,7 @@ func validateNamespaceName(tenant, namespace string) error {
 // allowed characters for property, namespace, cluster and topic
 // names are alphanumeric (a-zA-Z0-9) and these special chars -=:.
 // and % is allowed as part of valid URL encoding
-var patten = regexp.MustCompile("^[-=:.\\w]*$")
+var patten = regexp.MustCompile(`^[-=:.\w]*$`)
 
 func CheckName(name string) bool {
 	return patten.MatchString(name)


### PR DESCRIPTION
### Motivation
Resolve lint ci errors reported by #6 

Use `//nolint` instead of `// nolint` because machine-readable comments should have no space by Go convention. [Reference](https://golangci-lint.run/usage/false-positives/#nolint-directive).
