### PR TITLE
chore: replace deprecated ioutil pkg

### DIFF
--- a/pkg/admin/auth/oauth2_test.go
+++ b/pkg/admin/auth/oauth2_test.go
@@ -17,7 +17,6 @@ package auth
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -64,7 +63,7 @@ func mockKeyFile(server string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	kf, err := ioutil.TempFile(pwd, "test_oauth2")
+	kf, err := os.CreateTemp(pwd, "test_oauth2")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/admin/auth/token.go
+++ b/pkg/admin/auth/token.go
@@ -18,8 +18,8 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -51,7 +51,7 @@ func NewAuthenticationToken(token string, transport http.RoundTripper) (*TokenAu
 
 // NewAuthenticationTokenFromFile return a interface of a Provider with a string token file path.
 func NewAuthenticationTokenFromFile(tokenFilePath string, transport http.RoundTripper) (*TokenAuthProvider, error) {
-	data, err := ioutil.ReadFile(tokenFilePath)
+	data, err := os.ReadFile(tokenFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/admin/auth/transport.go
+++ b/pkg/admin/auth/transport.go
@@ -18,8 +18,8 @@ package auth
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/streamnative/pulsar-admin-go/pkg/admin/config"
 )
@@ -45,7 +45,7 @@ func NewDefaultTransport(config *config.Config) (http.RoundTripper, error) {
 		InsecureSkipVerify: config.TLSAllowInsecureConnection,
 	}
 	if len(config.TLSTrustCertsFilePath) > 0 {
-		rootCA, err := ioutil.ReadFile(config.TLSTrustCertsFilePath)
+		rootCA, err := os.ReadFile(config.TLSTrustCertsFilePath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/admin/subscription.go
+++ b/pkg/admin/subscription.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -229,7 +228,7 @@ func handleResp(topic utils.TopicName, resp *http.Response) ([]*utils.Message, e
 	}
 
 	// read data
-	payload, err := ioutil.ReadAll(resp.Body)
+	payload, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rest/client.go
+++ b/pkg/rest/client.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -139,7 +138,7 @@ func (c *Client) GetWithOptions(endpoint string, obj interface{}, params map[str
 				return nil, err
 			}
 		} else {
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return nil, err
 			}
@@ -395,7 +394,7 @@ func responseError(resp *http.Response) error {
 		Reason: resp.Status,
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		e.Reason = err.Error()
 		return e

--- a/pkg/rest/client_test.go
+++ b/pkg/rest/client_test.go
@@ -16,7 +16,7 @@
 package rest
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,7 +37,7 @@ func TestEncodeJSONBody(t *testing.T) {
 		r, err := encodeJSONBody(testcase.obj)
 		require.NoError(t, err)
 
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		require.NoError(t, err)
 
 		require.Equal(t, testcase.expected, len(b))


### PR DESCRIPTION
### Motivation
The `io/ioutil` pkg has already been [deprecated](https://github.com/go-critic/go-critic/issues/1019) since go1.16. We should replace it with `io` and `os` pkg.