### PR TITLE
fix: use auth provider as http round tripper

### DIFF
--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -82,47 +82,22 @@ func NewWithAuthProvider(config *config.Config, authProvider auth.Provider) Clie
 }
 
 // NewPulsarClientWithAuthProvider create a client with auth provider.
-func NewPulsarClientWithAuthProvider(config *config.Config,
-	authProvider auth.Provider) (Client, error) {
-	var transport http.RoundTripper
-
-	if authProvider != nil {
-		transport = authProvider.Transport()
-		if transport != nil {
-			transport = authProvider
-		}
-	}
-
-	if transport == nil {
-		defaultTransport, err := auth.NewDefaultTransport(config)
-		if err != nil {
-			return nil, err
-		}
-		if authProvider != nil {
-			authProvider.WithTransport(authProvider)
-		} else {
-			transport = defaultTransport
-		}
-	}
-
-	webServiceURL := config.WebServiceURL
-	if len(webServiceURL) == 0 {
+func NewPulsarClientWithAuthProvider(config *config.Config, authProvider auth.Provider) (Client, error) {
+	if len(config.WebServiceURL) == 0 {
 		config.WebServiceURL = DefaultWebServiceURL
 	}
 
-	c := &pulsarClient{
+	return &pulsarClient{
 		APIVersion: config.PulsarAPIVersion,
 		Client: &rest.Client{
 			ServiceURL:  config.WebServiceURL,
 			VersionInfo: ReleaseVersion,
 			HTTPClient: &http.Client{
 				Timeout:   DefaultHTTPTimeOutDuration,
-				Transport: transport,
+				Transport: authProvider,
 			},
 		},
-	}
-
-	return c, nil
+	}, nil
 }
 
 func (c *pulsarClient) endpoint(componentPath string, parts ...string) string {

--- a/pkg/admin/admin_test.go
+++ b/pkg/admin/admin_test.go
@@ -98,7 +98,9 @@ func TestNewWithTlsAllowInsecure(t *testing.T) {
 
 	pulsarClientS := admin.(*pulsarClient)
 	require.NotNil(t, pulsarClientS.Client.HTTPClient.Transport)
-	tr := pulsarClientS.Client.HTTPClient.Transport.(*http.Transport)
+
+	ap := pulsarClientS.Client.HTTPClient.Transport.(*auth.DefaultProvider)
+	tr := ap.Transport().(*http.Transport)
 	require.NotNil(t, tr)
 	require.NotNil(t, tr.TLSClientConfig)
 	require.True(t, tr.TLSClientConfig.InsecureSkipVerify)


### PR DESCRIPTION
### Motivation
The current auth provider is intended to be a http round tripper, and we should use it that way.