### PR TITLE
fix: config oauth2 with default flow

### DIFF
--- a/pkg/admin/auth/oauth2.go
+++ b/pkg/admin/auth/oauth2.go
@@ -183,13 +183,7 @@ func (o *OAuth2Provider) WithTransport(tripper http.RoundTripper) {
 }
 
 func (o *OAuth2Provider) Transport() http.RoundTripper {
-	return &transport{
-		source: o.source,
-		wrapped: &xoauth2.Transport{
-			Source: o.source,
-			Base:   o.defaultTransport,
-		},
-	}
+	return o.tokenTransport
 }
 
 func (o *OAuth2Provider) getRefresher(t oauth2.AuthorizationGrantType) (oauth2.AuthorizationGrantRefresher, error) {

--- a/pkg/admin/auth/provider.go
+++ b/pkg/admin/auth/provider.go
@@ -18,6 +18,8 @@ package auth
 import (
 	"net/http"
 
+	"github.com/apache/pulsar-client-go/oauth2"
+
 	"github.com/streamnative/pulsar-admin-go/pkg/admin/config"
 )
 
@@ -68,7 +70,11 @@ func GetAuthProvider(config *config.Config) (Provider, error) {
 	case OAuth2PluginName:
 		fallthrough
 	case OAuth2PluginShortName:
-		provider, err = NewAuthenticationOAuth2FromAuthParams(config.AuthParams, defaultTransport)
+		provider, err = NewAuthenticationOAuth2WithDefaultFlow(oauth2.Issuer{
+			IssuerEndpoint: config.IssuerEndpoint,
+			ClientID:       config.ClientID,
+			Audience:       config.Audience,
+		}, config.KeyFile)
 	default:
 		switch {
 		case len(config.TLSCertFile) > 0 && len(config.TLSKeyFile) > 0:


### PR DESCRIPTION
### Motivation

pulsar-admin-go is intended to be a library but an application. so that below code works:

```go
cfg := &pulsaradmin.Config{
	WebServiceURL: "",
	AuthPlugin:    "org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2",
	IssuerEndpoint:                "",
	ClientID:                      "",
	Audience:                      "",
	KeyFile:                       "",
}

admin, _ := pulsaradmin.NewClient(cfg)

clusters, _ := admin.Clusters().List()

```