### PR TITLE
feat: adds support for namespace scoped inactive topic policies (#30)

### DIFF
--- a/pkg/admin/namespace.go
+++ b/pkg/admin/namespace.go
@@ -262,6 +262,15 @@ type Namespaces interface {
 
 	// GetIsAllowAutoUpdateSchema gets whether to allow auto update schema on a namespace
 	GetIsAllowAutoUpdateSchema(namespace utils.NameSpaceName) (bool, error)
+
+	// GetInactiveTopicPolicies gets the inactive topic policies on a namespace
+	GetInactiveTopicPolicies(namespace utils.NameSpaceName) (utils.InactiveTopicPolicies, error)
+
+	// RemoveInactiveTopicPolicies removes inactive topic policies from a namespace
+	RemoveInactiveTopicPolicies(namespace utils.NameSpaceName) error
+
+	// SetInactiveTopicPolicies sets the inactive topic policies on a namespace
+	SetInactiveTopicPolicies(namespace utils.NameSpaceName, data utils.InactiveTopicPolicies) error
 }
 
 type namespaces struct {
@@ -844,4 +853,21 @@ func (n *namespaces) GetIsAllowAutoUpdateSchema(namespace utils.NameSpaceName) (
 	var result bool
 	err := n.pulsar.Client.Get(endpoint, &result)
 	return result, err
+}
+
+func (n *namespaces) GetInactiveTopicPolicies(namespace utils.NameSpaceName) (utils.InactiveTopicPolicies, error) {
+	var out utils.InactiveTopicPolicies
+	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "inactiveTopicPolicies")
+	err := n.pulsar.Client.Get(endpoint, &out)
+	return out, err
+}
+
+func (n *namespaces) RemoveInactiveTopicPolicies(namespace utils.NameSpaceName) error {
+	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "inactiveTopicPolicies")
+	return n.pulsar.Client.Delete(endpoint)
+}
+
+func (n *namespaces) SetInactiveTopicPolicies(namespace utils.NameSpaceName, data utils.InactiveTopicPolicies) error {
+	endpoint := n.pulsar.endpoint(n.basePath, namespace.String(), "inactiveTopicPolicies")
+	return n.pulsar.Client.Post(endpoint, data)
 }


### PR DESCRIPTION
## Motivation

The pulsar admin API has [namespace level inactive topic policies](https://github.com/apache/pulsar/blob/75779562d604993666c591c24f12b4133f860b5d/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java#L1591) as of v2.
The endpoint(s) use the same [InactiveTopicPolicies](https://github.com/apache/pulsar/blob/master/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/InactiveTopicPolicies.java#L31) so adding this feature is pretty straight forward.

Fixes: #30 