### PR TITLE
fix: use pointer for struct field so the default value from unmarshal is nil

### DIFF
--- a/pkg/utils/consumer_config.go
+++ b/pkg/utils/consumer_config.go
@@ -22,6 +22,6 @@ type ConsumerConfig struct {
 	ReceiverQueueSize  int               `json:"receiverQueueSize,omitempty" yaml:"receiverQueueSize"`
 	SchemaProperties   map[string]string `json:"schemaProperties,omitempty" yaml:"schemaProperties"`
 	ConsumerProperties map[string]string `json:"consumerProperties,omitempty" yaml:"consumerProperties"`
-	CryptoConfig       CryptoConfig      `json:"cryptoConfig,omitempty" yaml:"cryptoConfig"`
+	CryptoConfig       *CryptoConfig     `json:"cryptoConfig,omitempty" yaml:"cryptoConfig"`
 	PoolMessages       bool              `json:"poolMessages,omitempty" yaml:"poolMessages"`
 }

--- a/pkg/utils/data.go
+++ b/pkg/utils/data.go
@@ -163,6 +163,7 @@ type SinkData struct {
 	MaxMessageRetries            int         `json:"maxMessageRetries,omitempty"`
 	DeadLetterTopic              string      `json:"deadLetterTopic,omitempty"`
 	ProcessingGuarantees         string      `json:"processingGuarantees,omitempty"`
+	RetainKeyOrdering            bool        `json:"retainKeyOrdering,omitempty"`
 	Archive                      string      `json:"archive,omitempty"`
 	ClassName                    string      `json:"className,omitempty"`
 	SinkConfigFile               string      `json:"sinkConfigFile,omitempty"`

--- a/pkg/utils/function_confg.go
+++ b/pkg/utils/function_confg.go
@@ -36,7 +36,7 @@ type FunctionConfig struct {
 
 	Output string `json:"output,omitempty" yaml:"output"`
 
-	ProducerConfig      ProducerConfig    `json:"producerConfig,omitempty" yaml:"producerConfig"`
+	ProducerConfig      *ProducerConfig   `json:"producerConfig,omitempty" yaml:"producerConfig"`
 	CustomSchemaOutputs map[string]string `json:"customSchemaOutputs,omitempty" yaml:"customSchemaOutputs"`
 
 	OutputSerdeClassName string `json:"outputSerdeClassName,omitempty" yaml:"outputSerdeClassName"`

--- a/pkg/utils/producer_config.go
+++ b/pkg/utils/producer_config.go
@@ -20,8 +20,8 @@ type ProducerConfig struct {
 	//nolint
 	MaxPendingMessagesAcrossPartitions int `json:"maxPendingMessagesAcrossPartitions" yaml:"maxPendingMessagesAcrossPartitions"`
 
-	UseThreadLocalProducers bool         `json:"useThreadLocalProducers" yaml:"useThreadLocalProducers"`
-	CryptoConfig            CryptoConfig `json:"cryptoConfig" yaml:"cryptoConfig"`
-	BatchBuilder            string       `json:"batchBuilder" yaml:"batchBuilder"`
-	CompressionType         string       `json:"compressionType" yaml:"compressionType"`
+	UseThreadLocalProducers bool          `json:"useThreadLocalProducers" yaml:"useThreadLocalProducers"`
+	CryptoConfig            *CryptoConfig `json:"cryptoConfig" yaml:"cryptoConfig"`
+	BatchBuilder            string        `json:"batchBuilder" yaml:"batchBuilder"`
+	CompressionType         string        `json:"compressionType" yaml:"compressionType"`
 }

--- a/pkg/utils/source_config.go
+++ b/pkg/utils/source_config.go
@@ -21,7 +21,7 @@ type SourceConfig struct {
 	Name      string `json:"name,omitempty" yaml:"name"`
 	ClassName string `json:"className,omitempty" yaml:"className"`
 
-	ProducerConfig ProducerConfig `json:"producerConfig,omitempty" yaml:"producerConfig"`
+	ProducerConfig *ProducerConfig `json:"producerConfig,omitempty" yaml:"producerConfig"`
 
 	TopicName      string `json:"topicName,omitempty" yaml:"topicName"`
 	SerdeClassName string `json:"serdeClassName,omitempty" yaml:"serdeClassName"`
@@ -45,6 +45,6 @@ type SourceConfig struct {
 
 	CustomRuntimeOptions string `json:"customRuntimeOptions,omitempty" yaml:"customRuntimeOptions"`
 
-	BatchSourceConfig BatchSourceConfig `json:"batchSourceConfig,omitempty" yaml:"batchSourceConfig"`
-	BatchBuilder      string            `json:"batchBuilder,omitempty" yaml:"batchBuilder"`
+	BatchSourceConfig *BatchSourceConfig `json:"batchSourceConfig,omitempty" yaml:"batchSourceConfig"`
+	BatchBuilder      string             `json:"batchBuilder,omitempty" yaml:"batchBuilder"`
 }


### PR DESCRIPTION
<!--

## Contribution Checklist 

- Use [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).
- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- More details in [CONTRIBUTING.md](../CONTRIBUTING.md)

-->


<!-- Does this PR fix an issue -->

Fixes #TODO

## Motivation

1. non-pointer struct field will create an empty struct when doing unmarshal for an empty value, which is not expected

## Modifications

1. use pointer for `ProducerConfig`, `CryptoConfig` and `BatchSourceConfig`
2. add `RetainKeyOrdering` to the sinkData

## Verification

<!-- TODO: Say how you tested your changes. -->
